### PR TITLE
Go version lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.15-alpine as builder
 
 # Download and install dependencies
 RUN apk update && apk add --no-cache git
@@ -13,7 +13,7 @@ ENV CGO_ENABLED=0
 RUN GOOS=linux go build -a -installsuffix cgo -ldflags '-s -w -extldflags "-static"' .
 
 # Create docker
-FROM scratch
+FROM alpine
 COPY --from=builder /go/src/github.com/maesoser/tplink_exporter/tplink_exporter /app/
 RUN adduser -D tplink
 USER tplink


### PR DESCRIPTION
After go `get got` deprecated it was no longer building, so I pinned a version to latest one that builds.
I also switched from `scratch` to `apline` because I had some issues while building on Windows machine and that fixed it.

BTW I looks like your scraper does not work for routers with newer firmware I suggest adding `tested with version X.XX.X` or `works up to version Y.YY`